### PR TITLE
dep: bump tailwindcss to 4.0.0-alpha.25

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -71,20 +71,20 @@ jobs:
       - run: "gem install pkg/tailwindcss-ruby-*.gem"
       - run: "tailwindcss --help"
 
-  linux-musl-install:
-    needs: ["package"]
-    runs-on: ubuntu-latest
-    container:
-      image: ruby:3.2-alpine
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: gem-x86_64-linux
-          path: pkg
-      - run: "apk add build-base" # to compile racc, etc.
-      - run: "gem update --system" # let's make sure the latest is working for us (upstream test, see #200)
-      - run: "gem install pkg/tailwindcss-ruby-*.gem"
-      - run: "tailwindcss --help"
+  # linux-musl-install:
+  #   needs: ["package"]
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ruby:3.2-alpine
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: gem-x86_64-linux
+  #         path: pkg
+  #     - run: "apk add build-base" # to compile racc, etc.
+  #     - run: "gem update --system" # let's make sure the latest is working for us (upstream test, see #200)
+  #     - run: "gem install pkg/tailwindcss-ruby-*.gem"
+  #     - run: "tailwindcss --help"
 
   # linux-arm-install:
   #   needs: ["package"]

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -19,7 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "arm64-darwin", "x86_64-linux", "arm-linux"]
+        platform:
+          - "ruby"
+          - "x64-mingw32"
+          - "x64-mingw-ucrt"
+          - "x86_64-darwin"
+          - "arm64-darwin"
+          - "x86_64-linux"
+#          - "arm-linux"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,22 +86,22 @@ jobs:
       - run: "gem install pkg/tailwindcss-ruby-*.gem"
       - run: "tailwindcss --help"
 
-  linux-arm-install:
-    needs: ["package"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: gem-arm-linux
-          path: pkg
-      - run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker run --rm -v "$(pwd):/test" -w /test --platform=linux/arm/v7 ruby:3.2 \
-            /bin/bash -c "
-              set -ex
-              gem install pkg/tailwindcss-ruby-*.gem
-              tailwindcss --help
-            "
+  # linux-arm-install:
+  #   needs: ["package"]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: gem-arm-linux
+  #         path: pkg
+  #     - run: |
+  #         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  #         docker run --rm -v "$(pwd):/test" -w /test --platform=linux/arm/v7 ruby:3.2 \
+  #           /bin/bash -c "
+  #             set -ex
+  #             gem install pkg/tailwindcss-ruby-*.gem
+  #             tailwindcss --help
+  #           "
 
   darwin-x86_64-install:
     needs: ["package"]

--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v3.4.13"
+      VERSION = "v4.0.0-alpha.25"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {
@@ -11,7 +11,7 @@ module Tailwindcss
         "x86_64-darwin" => "tailwindcss-macos-x64",
         "x86_64-linux" => "tailwindcss-linux-x64",
         "aarch64-linux" => "tailwindcss-linux-arm64",
-        "arm-linux" => "tailwindcss-linux-armv7",
+#        "arm-linux" => "tailwindcss-linux-armv7",
       }
     end
   end


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.0-alpha.25

Note that this upstream release

- does not ship an armv7 release
- does not ship a musl-compatible linux binary

So those native gems will not be available.