### PR TITLE
dep: bump tailwindcss to 4.0.0-alpha.26

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -36,6 +36,7 @@ jobs:
           ruby-version: ${{matrix.ruby}}
       - run: gem install bundler -v ">= 2.3.22" # for "add --path"
       - run: bundle install --local || bundle install
+      - run: bundle exec rake download
       - run: git clone --depth=1 ${{matrix.url}} ${{matrix.name}}
       - name: ${{matrix.name}} test suite
         working-directory: ${{matrix.name}}

--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v4.0.0-alpha.25"
+      VERSION = "v4.0.0-alpha.26"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.0-alpha.26