### PR TITLE
dep: bump tailwindcss to v3.4.14

### DIFF
--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v3.4.13"
+      VERSION = "v3.4.14"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.14