### PR TITLE
dep: bump tailwindcss to 4.0.0-alpha.28

### DIFF
--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v4.0.0-alpha.27"
+      VERSION = "v4.0.0-alpha.28"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.0-alpha.28