### PR TITLE
ci: restore the alpine test

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -71,20 +71,20 @@ jobs:
       - run: "gem install pkg/tailwindcss-ruby-*.gem"
       - run: "tailwindcss --help"
 
-  # linux-musl-install:
-  #   needs: ["package"]
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ruby:3.2-alpine
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: gem-x86_64-linux
-  #         path: pkg
-  #     - run: "apk add build-base" # to compile racc, etc.
-  #     - run: "gem update --system" # let's make sure the latest is working for us (upstream test, see #200)
-  #     - run: "gem install pkg/tailwindcss-ruby-*.gem"
-  #     - run: "tailwindcss --help"
+  linux-musl-install:
+    needs: ["package"]
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:3.2-alpine
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: gem-x86_64-linux
+          path: pkg
+      - run: "apk add build-base" # to compile racc, etc.
+      - run: "gem update --system" # let's make sure the latest is working for us (upstream test, see #200)
+      - run: "gem install pkg/tailwindcss-ruby-*.gem"
+      - run: "tailwindcss --help"
 
   # linux-arm-install:
   #   needs: ["package"]


### PR DESCRIPTION
See c88c056b where this test was commented out because the upstream build for 4.0.0-alpha.25 is dynamically linked against glibc.