### PR TITLE
Show more useful link for unsupported platform error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gem install tailwindcss-ruby
 
 ### Using a local installation of `tailwindcss`
 
-If you are not able to use the vendored standalone executables (for example, if you're on an unsupported platform), you can use a local installation of the `tailwindcss` executable by setting an environment variable named `TAILWINDCSS_INSTALL_DIR` to the directory path containing the executable.
+If you are not able to use the vendored standalone executables (for example, if you're on an unsupported platform), you can use a [local installation](https://tailwindcss.com/docs/installation) of the `tailwindcss` executable by setting an environment variable named `TAILWINDCSS_INSTALL_DIR` to the directory path containing the executable.
 
 For example, if you've installed `tailwindcss` so that the executable is found at `/path/to/node_modules/bin/tailwindcss`, then you should set your environment variable like so:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ gem install tailwindcss-ruby
 
 ### Using a local installation of `tailwindcss`
 
+<!-- note that this section's title is deeplinked from an error message, do not change -->
+
 If you are not able to use the vendored standalone executables (for example, if you're on an unsupported platform), you can use a [local installation](https://tailwindcss.com/docs/installation) of the `tailwindcss` executable by setting an environment variable named `TAILWINDCSS_INSTALL_DIR` to the directory path containing the executable.
 
 For example, if you've installed `tailwindcss` so that the executable is found at `/path/to/node_modules/bin/tailwindcss`, then you should set your environment variable like so:

--- a/lib/tailwindcss/ruby.rb
+++ b/lib/tailwindcss/ruby.rb
@@ -41,7 +41,8 @@ module Tailwindcss
           if Tailwindcss::Ruby::Upstream::NATIVE_PLATFORMS.keys.none? { |p| Gem::Platform.match_gem?(Gem::Platform.new(p), GEM_NAME) }
             raise UnsupportedPlatformException, <<~MESSAGE
               #{GEM_NAME} does not support the #{platform} platform
-              Please install tailwindcss following instructions at https://tailwindcss.com/docs/installation
+              See https://github.com/flavorjones/tailwindcss-ruby#using-a-local-installation-of-tailwindcss
+              for more details.
             MESSAGE
           end
 


### PR DESCRIPTION
While the current link indeed helps with installing tailwindcss itself, it's missing the important step when this gem is used as part of a dependency (like tailwindcss-rails) as just installing it via npm doesn't make this library automatically picks up the installation.

An inline instruction to install it locally and set the env variable would probably be more immediately useful but I'm not good with words so I just made it as simple as possible 🙂 Feel free to adjust as needed.

Resolves #20.