### PR TITLE
dep: bump tailwindcss to 3.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## v3.4.16
+
+* Update `tailwindcss` to [v3.4.16](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.16). (#33) @flavorjones
+
+
 ## v3.4.15
 
 * Update `tailwindcss` to [v3.4.15](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.15). (#19) @flavorjones

--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v3.4.15"
+      VERSION = "v3.4.16"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {

--- a/lib/tailwindcss/ruby/version.rb
+++ b/lib/tailwindcss/ruby/version.rb
@@ -2,6 +2,6 @@
 
 module Tailwindcss
   module Ruby
-    VERSION = "3.4.15"
+    VERSION = "3.4.16"
   end
 end


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.16