### PR TITLE
dep: update to Tailwind CSS v4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # tailwindcss-ruby changelog
 
+
+## v4.0.5
+
+* Update to [Tailwind CSS v4.0.5](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.5) @avifs
+
+  Upgrade guide at https://tailwindcss.com/docs/upgrade-guide
+
+
 ## v4.0.4
 
 * Update to [Tailwind CSS v4.0.4](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.4) @flavorjones

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tailwindcss-ruby (4.0.3)
+    tailwindcss-ruby (4.0.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v4.0.4"
+      VERSION = "v4.0.5"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {

--- a/lib/tailwindcss/ruby/version.rb
+++ b/lib/tailwindcss/ruby/version.rb
@@ -2,6 +2,6 @@
 
 module Tailwindcss
   module Ruby
-    VERSION = "4.0.4"
+    VERSION = "4.0.5"
   end
 end


### PR DESCRIPTION
Copied the updates for the previous four `v4.0.x` patch updates by incrementing the version across the four relevant files.