### PR TITLE
ci: skip the downstream rails upgrade test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,10 +31,10 @@ jobs:
             name: rails-install
             command: "env TAILWINDCSSOPTS=--path=../../.. test/integration/user_install_test.sh"
             ruby: "3.4"
-          - url: https://github.com/rails/tailwindcss-rails
-            name: rails-upgrade
-            command: "env TAILWINDCSSOPTS=--path=../../.. test/integration/user_upgrade_test.sh"
-            ruby: "3.4"
+          # - url: https://github.com/rails/tailwindcss-rails
+          #   name: rails-upgrade
+          #   command: "env TAILWINDCSSOPTS=--path=../../.. test/integration/user_upgrade_test.sh"
+          #   ruby: "3.4"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The tailwind upgrade tool started failing in the CI environment

ref: https://github.com/rails/tailwindcss-rails/pull/527