### PR TITLE
Automate shipping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,73 @@
-# empty file so I can iterate on the workflow in a PR
 name: release
+
+concurrency:
+  group: "release-${{ inputs.version_tag }}"
+
 on:
   workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Version tag to release (e.g., v4.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "build (${{ matrix.platform }})"
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - "ruby"
+          - "aarch64-linux-gnu"
+          - "aarch64-linux-musl"
+          - "arm64-darwin"
+          - "x64-mingw-ucrt"
+          - "x64-mingw32"
+          - "x86_64-darwin"
+          - "x86_64-linux-gnu"
+          - "x86_64-linux-musl"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.version_tag }}
+          persist-credentials: false
+      - run: rm -f Gemfile.lock
+      - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1.292.0
+        with:
+          ruby-version: "4.0"
+          bundler: latest
+          bundler-cache: true
+      - env:
+          PLATFORM: ${{ matrix.platform }}
+        run: "bundle exec rake gem:${PLATFORM}"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-${{ inputs.version_tag }}-gem-${{ matrix.platform }}
+          path: pkg
+          retention-days: 1
+
+  push:
+    name: "Push gems to RubyGems.org"
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for OIDC trusted publishing to RubyGems.org
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: gems
+          pattern: release-${{ inputs.version_tag }}-gem-*
+          merge-multiple: true
+      - uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+      - name: Push gems
+        run: |
+          for gem in gems/*.gem; do
+            echo "Pushing $gem ..."
+            gem push "$gem" || echo "WARNING: Failed to push $gem (may already exist)"
+          done

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,128 @@
-# empty file so I can iterate on the workflow in a PR
 name: upstream
+
+concurrency:
+  group: upstream
+
 on:
+  schedule:
+    - cron: "0 15 * * *" # daily at 15:00 UTC
   workflow_dispatch:
+    inputs:
+      upstream_tag:
+        description: "Upstream tag to bump to (e.g., v4.2.1). Leave blank to auto-detect latest."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: "Detect and PR new upstream release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Determine upstream tag
+        id: upstream
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUTS_UPSTREAM_TAG: ${{ inputs.upstream_tag }}
+        run: |
+          if [[ -n "${INPUTS_UPSTREAM_TAG}" ]]; then
+            upstream_tag="${INPUTS_UPSTREAM_TAG}"
+          else
+            upstream_tag=$(gh release view --repo tailwindlabs/tailwindcss --json tagName --jq '.tagName')
+          fi
+
+          # verify the release exists upstream
+          gh release view "${upstream_tag}" --repo tailwindlabs/tailwindcss --json tagName > /dev/null
+
+          current_tag=$(grep 'VERSION' lib/tailwindcss/ruby/upstream.rb | sed -E 's/.*"(.*)".*/\1/')
+
+          echo "upstream_tag=${upstream_tag}" >> "$GITHUB_OUTPUT"
+          echo "current_tag=${current_tag}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$upstream_tag" == "$current_tag" ]]; then
+            echo "Already up to date (${current_tag})"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New release: ${current_tag} → ${upstream_tag}"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing PR
+        if: steps.upstream.outputs.needed == 'true'
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STEPS_UPSTREAM_OUTPUTS_UPSTREAM_TAG: ${{ steps.upstream.outputs.upstream_tag }}
+        run: |
+          upstream_tag="${STEPS_UPSTREAM_OUTPUTS_UPSTREAM_TAG}"
+          branch="bot-dep-tailwindcss-${upstream_tag}"
+          pr=$(gh pr list --head "${branch}" --json number --jq '.[0].number // empty')
+          if [[ -n "$pr" ]]; then
+            echo "PR #${pr} already exists for ${upstream_tag}"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump upstream version
+        if: steps.upstream.outputs.needed == 'true' && steps.existing_pr.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STEPS_UPSTREAM_OUTPUTS_UPSTREAM_TAG: ${{ steps.upstream.outputs.upstream_tag }}
+        run: |
+          upstream_tag="${STEPS_UPSTREAM_OUTPUTS_UPSTREAM_TAG}"
+          gem_version=$(echo "$upstream_tag" | sed -E 's/^v//' | sed -E 's/-/./')
+          gem_tag="v${gem_version}"
+
+          # update version files
+          sed -E -i "s/^(\s+)VERSION\s+=.*/\1VERSION = \"${upstream_tag}\"/" lib/tailwindcss/ruby/upstream.rb
+          sed -E -i "s/^(\s+)VERSION\s+=.*/\1VERSION = \"${gem_version}\"/" lib/tailwindcss/ruby/version.rb
+
+          # update changelog
+          replacement_text="## ${gem_tag}\n\n* Update to [Tailwind CSS ${upstream_tag}](https:\/\/github.com\/tailwindlabs\/tailwindcss\/releases\/tag\/${upstream_tag})"
+          sed -E -i "0,/^##/{s|^##|${replacement_text}\n\n##|}" CHANGELOG.md
+
+      - name: Install dependencies
+        if: steps.upstream.outputs.needed == 'true' && steps.existing_pr.outputs.exists == 'false'
+        run: rm -f Gemfile.lock
+      - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1.292.0
+        if: steps.upstream.outputs.needed == 'true' && steps.existing_pr.outputs.exists == 'false'
+        with:
+          ruby-version: "3.2"
+          bundler: latest
+          bundler-cache: true
+
+      - name: Verify upstream checksums
+        if: steps.upstream.outputs.needed == 'true' && steps.existing_pr.outputs.exists == 'false'
+        run: bundle exec rake download
+
+      - name: Create PR
+        if: steps.upstream.outputs.needed == 'true' && steps.existing_pr.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.TAILWINDCSS_RUBY_PR_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STEPS_UPSTREAM_OUTPUTS_UPSTREAM_TAG: ${{ steps.upstream.outputs.upstream_tag }}
+        run: |
+          upstream_tag="${STEPS_UPSTREAM_OUTPUTS_UPSTREAM_TAG}"
+          branch="bot-dep-tailwindcss-${upstream_tag}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git switch -c "${branch}"
+          git add lib CHANGELOG.md Gemfile*
+          git commit -m "$(printf "dep: update to Tailwind CSS %s\n\nhttps://github.com/tailwindlabs/tailwindcss/releases/tag/%s" "${upstream_tag}" "${upstream_tag}")"
+
+          git push --force -u origin "${branch}"
+
+          gh pr create \
+            --title "dep: update to Tailwind CSS ${upstream_tag}" \
+            --body "$(printf "Update to [Tailwind CSS %s](https://github.com/tailwindlabs/tailwindcss/releases/tag/%s).\n\nThis PR was created automatically by the upstream workflow." "${upstream_tag}" "${upstream_tag}")"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,27 +4,26 @@ This doc is a brief introduction on modifying and maintaining this gem.
 
 ## Updating to the latest upstream tailwindcss version
 
-Please don't submit PRs to the maintainer with an upstream bump.
+We have a Github Actions workflow that runs once a day to check for new upstream versions, and will
+create a new pull request with the bump. You only need to review and merged it!
 
-- [ ] run `bin/bump-upstream`
-- [ ] push the branch, create a PR
+If you really need to do it manually, you can use the `bin/bump-upstream` script, however, we may
+not be keeping that up to date, and you should double-check everything.
 
 ## Cutting a release of tailwindcss-ruby
 
-- if it's just bumping the upstream:
-  - [ ] follow the steps above
-  - [ ] when the PR is green, merge the PR
-  - [ ] create a git tag (after updating local `main`)
-- else if the gem is being changed in some other way:
-  - [ ] update `lib/tailwindcss/ruby/version.rb`
-  - [ ] update `CHANGELOG.md`
+- Prep work
+  - [ ] update `lib/tailwindcss/ruby/version.rb` if necessary
+  - [ ] update `CHANGELOG.md` if necessary
   - [ ] `git commit`
   - [ ] `git tag`
-- build the native gems:
+  - [ ] `git push && git push --tags`
+- Automated release with Github Actions workflow 
+  - [ ] go to https://github.com/flavorjones/tailwindcss-ruby/actions/workflows/release.yml
+  - [ ] run the workflow, passing in the git tag as input
+- Manual release
   - [ ] `bundle exec rake clobber` (if needed to clean up old tailwindcss executables)
   - [ ] `bundle exec rake package`
-- push source and gems:
   - [ ] `for g in pkg/*.gem ; do gem push $g ; done`
-  - [ ] `git push && git push --tags`
-- announce
-  - [ ] create a release at https://github.com/flavorjones/tailwindcss-ruby/releases
+- Announce
+  - [ ] create a release at https://github.com/flavorjones/tailwindcss-ruby/releases (this should be automated, too)


### PR DESCRIPTION
Closes https://github.com/flavorjones/tailwindcss-ruby/issues/50

Two new workflows:

- upstream.yml watches tailwindlabs/tailwindcss for new releases and ships a PR
- release.yml publishes a new gem release

Both of these need testing/vetting. I've run zizmor against them both to harden them.