### PR TITLE
ci: use $GITHUB_WORKSPACE for downstream tailwindcss-rails integration tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,11 +31,11 @@ jobs:
             ruby: "3.4"
           - url: https://github.com/rails/tailwindcss-rails
             name: rails-install
-            command: "env TAILWINDCSSOPTS=--path=../../.. test/integration/user_install_test.sh"
+            command: 'env TAILWINDCSSOPTS="--path=$GITHUB_WORKSPACE" test/integration/user_install_test.sh'
             ruby: "3.4"
           - url: https://github.com/rails/tailwindcss-rails
             name: rails-upgrade
-            command: "env TAILWINDCSSOPTS=--path=../../.. test/integration/user_upgrade_test.sh"
+            command: 'env TAILWINDCSSOPTS="--path=$GITHUB_WORKSPACE" test/integration/user_upgrade_test.sh'
             ruby: "3.4"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Necessary after rails/tailwindcss-rails#615.