### PR TITLE
dep: update to Tailwind CSS v4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tailwindcss-ruby changelog
 
+## v4.3.2
+
+* Update to [Tailwind CSS v4.3.2](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.3.2)
+
 ## v4.3.1
 
 * Update to [Tailwind CSS v4.3.1](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    tailwindcss-ruby (4.3.1)
+    tailwindcss-ruby (4.3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    json (2.19.9)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     minitest (5.27.0)
@@ -67,8 +67,8 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
@@ -86,9 +86,9 @@ CHECKSUMS
   standard (1.55.0) sha256=8a8f2c3e681a4db3aafde1b301561b0f3d7c5f06c160167cb744a4d7baf0426e
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
-  tailwindcss-ruby (4.3.1)
+  tailwindcss-ruby (4.3.2)
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
 
 BUNDLED WITH
-  4.0.14
+  4.0.15

--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   module Ruby
     module Upstream
-      VERSION = "v4.3.1"
+      VERSION = "v4.3.2"
 
       # rubygems platform name => upstream release filename
       NATIVE_PLATFORMS = {

--- a/lib/tailwindcss/ruby/version.rb
+++ b/lib/tailwindcss/ruby/version.rb
@@ -2,6 +2,6 @@
 
 module Tailwindcss
   module Ruby
-    VERSION = "4.3.1"
+    VERSION = "4.3.2"
   end
 end


### PR DESCRIPTION
Update to [Tailwind CSS v4.3.2](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.3.2).

This PR was created automatically by the upstream workflow.