### PR TITLE
Add gnu/musl linux platform variants for Ruby 4 compatibility

### DIFF
--- a/lib/tailwindcss/ruby/upstream.rb
+++ b/lib/tailwindcss/ruby/upstream.rb
@@ -10,7 +10,11 @@ module Tailwindcss
         "x64-mingw-ucrt" => "tailwindcss-windows-x64.exe",
         "x86_64-darwin" => "tailwindcss-macos-x64",
         "x86_64-linux" => "tailwindcss-linux-x64",
+        "x86_64-linux-gnu" => "tailwindcss-linux-x64",
+        "x86_64-linux-musl" => "tailwindcss-linux-x64",
         "aarch64-linux" => "tailwindcss-linux-arm64",
+        "aarch64-linux-gnu" => "tailwindcss-linux-arm64",
+        "aarch64-linux-musl" => "tailwindcss-linux-arm64",
         "arm-linux" => "tailwindcss-linux-armv7"
       }
     end


### PR DESCRIPTION
## Summary

- Ruby 4 / newer Bundler resolves linux platforms as `x86_64-linux-gnu` and `aarch64-linux-gnu` instead of `x86_64-linux` and `aarch64-linux`
- Without these entries, `bundle install` fails with `Could not find gems matching 'tailwindcss-ruby (< 4.0)' valid for all resolution platforms`
- Adds `x86_64-linux-gnu`, `x86_64-linux-musl`, `aarch64-linux-gnu`, and `aarch64-linux-musl` platform mappings to `NATIVE_PLATFORMS`, pointing to the same upstream binaries

## Test plan

- [x] `bundle install` resolves `tailwindcss-ruby < 4.0` on Ruby 4.0.5
- [x] `rake package` builds gems for all platform variants including new ones
- [x] All binary checksums verified against upstream